### PR TITLE
Fix uninitialized results variable

### DIFF
--- a/vision/interactive_tracker.py
+++ b/vision/interactive_tracker.py
@@ -57,6 +57,7 @@ if save_video:
 selected_object_id = None
 selected_bbox = None
 selected_center = None
+results = None
 
 
 def get_center(x1: int, y1: int, x2: int, y2: int) -> Tuple[int, int]:
@@ -133,8 +134,8 @@ def click_event(event: int, x: int, y: int, flags: int, param) -> None:
         flags (int): Any relevant flags passed by OpenCV.
         param (Any): Additional parameters (not used).
     """
-    global selected_object_id
-    if event == cv2.EVENT_LBUTTONDOWN:
+    global selected_object_id, results
+    if event == cv2.EVENT_LBUTTONDOWN and results is not None:
         detections = results[0].boxes.data if results[0].boxes is not None else []
         if detections is not None:
             min_area = float("inf")


### PR DESCRIPTION
## Summary
- initialize `results` before use in `interactive_tracker.py`
- guard click handler when `results` is `None`

## Testing
- `python -m py_compile vision/interactive_tracker.py`


------
https://chatgpt.com/codex/tasks/task_e_684169d5dfd48328b8fedbed2bb8f4c5