### PR TITLE
Integrated antelopev2 from InsightFace for face embedding

### DIFF
--- a/vision/agent/face_memory.py
+++ b/vision/agent/face_memory.py
@@ -1,16 +1,14 @@
 import numpy as np
 import time
 import cv2
-import torch # Needed so the CUDAExecutionProvider can be created (access the CUDA that was installed with PyTorch). 
-             # Can also use onnxruntime.preload_dlls() before starting the session.
 import onnxruntime as ort
 from sklearn.metrics.pairwise import cosine_similarity
-from pathlib import Path
 
 class MobileFaceEmbedder:
     def __init__(self):
         model_path = str("C:/Users/bkarr/.insightface/models/antelopev2/antelopev2/1k3d68.onnx")
         
+        ort.preload_dlls() # Needed so the CUDAExecutionProvider can be created (access the CUDA that was installed with PyTorch). 
         self.session = ort.InferenceSession(
             model_path,
             providers=["CUDAExecutionProvider"]
@@ -18,11 +16,11 @@ class MobileFaceEmbedder:
         self.input_name = self.session.get_inputs()[0].name
 
     def preprocess(self, face_crop_bgr):
-        img = cv2.resize(face_crop_bgr, (112, 112))
+        img = cv2.resize(face_crop_bgr, (192, 192))
         img = cv2.cvtColor(img, cv2.COLOR_BGR2RGB).astype(np.float32)
         img = (img / 255.0 - 0.5) / 0.5  # Normalize to [-1, 1]
         img = np.transpose(img, (2, 0, 1))  # HWC → CHW
-        img = np.expand_dims(img, axis=0).astype(np.float32)  # (1, 3, 112, 112)
+        img = np.expand_dims(img, axis=0).astype(np.float32)  # (1, 3, 192, 192)
         return img
 
     def get_embedding(self, face_crop_bgr):

--- a/vision/agent/face_memory.py
+++ b/vision/agent/face_memory.py
@@ -1,6 +1,8 @@
 import numpy as np
 import time
 import cv2
+import torch # Needed so the CUDAExecutionProvider can be created (access the CUDA that was installed with PyTorch). 
+             # Can also use onnxruntime.preload_dlls() before starting the session.
 import onnxruntime as ort
 from sklearn.metrics.pairwise import cosine_similarity
 
@@ -8,7 +10,6 @@ class MobileFaceEmbedder:
     def __init__(self):
         model_path = str("C:/Users/bkarr/.insightface/models/antelopev2/antelopev2/1k3d68.onnx")
         
-        ort.preload_dlls() # Needed so the CUDAExecutionProvider can be created (access the CUDA that was installed with PyTorch). 
         self.session = ort.InferenceSession(
             model_path,
             providers=["CUDAExecutionProvider"]
@@ -19,7 +20,7 @@ class MobileFaceEmbedder:
         img = cv2.resize(face_crop_bgr, (192, 192))
         img = cv2.cvtColor(img, cv2.COLOR_BGR2RGB).astype(np.float32)
         img = (img / 255.0 - 0.5) / 0.5  # Normalize to [-1, 1]
-        img = np.transpose(img, (2, 0, 1))  # HWC → CHW
+        img = np.transpose(img, (2, 0, 1))  # HWC to CHW
         img = np.expand_dims(img, axis=0).astype(np.float32)  # (1, 3, 192, 192)
         return img
 

--- a/vision/agent/face_memory.py
+++ b/vision/agent/face_memory.py
@@ -1,37 +1,56 @@
-import face_recognition
 import numpy as np
 import time
 import cv2
+import torch # Needed so the CUDAExecutionProvider can be created (access the CUDA that was installed with PyTorch). 
+             # Can also use onnxruntime.preload_dlls() before starting the session.
+import onnxruntime as ort
+from sklearn.metrics.pairwise import cosine_similarity
+from pathlib import Path
+
+class MobileFaceEmbedder:
+    def __init__(self):
+        model_path = str("C:/Users/bkarr/.insightface/models/antelopev2/antelopev2/1k3d68.onnx")
+        
+        self.session = ort.InferenceSession(
+            model_path,
+            providers=["CUDAExecutionProvider"]
+        )
+        self.input_name = self.session.get_inputs()[0].name
+
+    def preprocess(self, face_crop_bgr):
+        img = cv2.resize(face_crop_bgr, (112, 112))
+        img = cv2.cvtColor(img, cv2.COLOR_BGR2RGB).astype(np.float32)
+        img = (img / 255.0 - 0.5) / 0.5  # Normalize to [-1, 1]
+        img = np.transpose(img, (2, 0, 1))  # HWC → CHW
+        img = np.expand_dims(img, axis=0).astype(np.float32)  # (1, 3, 112, 112)
+        return img
+
+    def get_embedding(self, face_crop_bgr):
+        img = self.preprocess(face_crop_bgr)
+        emb = self.session.run(None, {self.input_name: img})[0]
+        return emb[0]  # 512-dim vector
+
 
 class FaceMemory:
     def __init__(self, threshold=0.6):
         self.memory = []
         self.next_id = 1
         self.threshold = threshold
+        self.embedder = MobileFaceEmbedder()
 
     def match_or_add(self, face_crop):
-        # Convert from BGR (OpenCV) to RGB for face_recognition
         try:
-            rgb_crop = cv2.cvtColor(face_crop, cv2.COLOR_BGR2RGB)
+            emb = self.embedder.get_embedding(face_crop)
         except:
             return None
-        # Detect face locations in the crop
-        locs = face_recognition.face_locations(rgb_crop)
-        if not locs:
-            return None
-        
-        encs = face_recognition.face_encodings(rgb_crop, known_face_locations=locs)
-        if not encs:
-            return None
-        emb = encs[0]
 
-        known_embs = [e["embedding"] for e in self.memory]
+        known_embs = [entry["embedding"] for entry in self.memory]
         if known_embs:
-            dists = face_recognition.face_distance(known_embs, emb)
-            best = np.argmin(dists)
-            if dists[best] < self.threshold:
-                self.memory[best]["last_seen"] = time.time()
-                return self.memory[best]["id"]
+            sims = cosine_similarity([emb], known_embs)[0]
+            best_idx = np.argmax(sims)
+            if sims[best_idx] > self.threshold:
+                self.memory[best_idx]["last_seen"] = time.time()
+                return self.memory[best_idx]["id"]
 
         new_id = self.next_id
         self.memory.append({

--- a/vision/agent/face_memory.py
+++ b/vision/agent/face_memory.py
@@ -6,7 +6,7 @@ import torch # Needed so the CUDAExecutionProvider can be created (access the CU
 import onnxruntime as ort
 from sklearn.metrics.pairwise import cosine_similarity
 
-class MobileFaceEmbedder:
+class FaceEmbedder:
     def __init__(self):
         model_path = str("C:/Users/bkarr/.insightface/models/antelopev2/antelopev2/1k3d68.onnx")
         
@@ -35,7 +35,7 @@ class FaceMemory:
         self.memory = []
         self.next_id = 1
         self.threshold = threshold
-        self.embedder = MobileFaceEmbedder()
+        self.embedder = FaceEmbedder()
 
     def match_or_add(self, face_crop):
         try:

--- a/vision/ui/interactive_tracker.py
+++ b/vision/ui/interactive_tracker.py
@@ -136,7 +136,6 @@ while cap.isOpened():
         detections=detections,
         selected_id=selected_object_id,
         face_memory=face_memory, 
-        frame_idx=fps_counter,
         previous_ids=previous_ids)
 
 

--- a/vision/ui/tracking_utils.py
+++ b/vision/ui/tracking_utils.py
@@ -100,7 +100,7 @@ def show_fps(im, fps_counter, fps_display, fps_timer):
     return fps_counter, fps_display, fps_timer
 
 
-def process_detections(frame, detections, selected_id, face_memory, frame_idx, previous_ids):
+def process_detections(frame, detections, selected_id, face_memory, previous_ids):
     annotator = Annotator(frame)    
     center = None
     for track in detections:
@@ -112,10 +112,9 @@ def process_detections(frame, detections, selected_id, face_memory, frame_idx, p
         track_id = int(track[4]) if len(track) >= 7 else -1
         face_crop = frame[y1:y2, x1:x2]
 
-        if frame_idx % 30 == 0:
-            matched_id = face_memory.match_or_add(face_crop)
-            if matched_id is not None:
-                previous_ids[track_id] = matched_id
+        matched_id = face_memory.match_or_add(face_crop)
+        if matched_id is not None:
+            previous_ids[track_id] = matched_id
 
         else:
             matched_id = previous_ids.get(track_id, None)


### PR DESCRIPTION
Replaced the face_recognition library with InsightFace's antelopev2 (ONNX-based) model, to enable GPU-accelerated face embedding.

Inference now meets the 30 FPS requirement, resolving performance bottlenecks caused by CPU-bound recognition. 

Closes #7 – addresses FPS drops caused by the previous implementation.